### PR TITLE
fix: filtered invoices/expenses return back to their original state

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { useContext, useState } from 'react';
+import { useContext, useState, useEffect } from 'react';
 import { Context } from './context/StateContext';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -21,6 +21,11 @@ export default function Header({ title, payments, setShowModal }) {
     filterExpenses,
     setFilterExpenses,
   } = useContext(Context);
+
+  useEffect(() => {
+    setFilterInvoices([]);
+    setFilterExpenses([]);
+  }, [router.pathname]);
 
   function filterPaymentsHandler(e) {
     if (title === 'Invoices') {


### PR DESCRIPTION
## Description
This PR request fixes the issue that occurs whenever a user applies a filter to the list of invoices or expenses list, navigates to a new page, and then returns back to the list, the original list disappears and only the filtered results are displayed. This causes confusion for users who are expecting the original list to be displayed when they return to the page.

To address this issue, I implemented a `useEffect` to run whenever the user navigates to a new page, updating `setFilterInvoices` and `setFilterExpenses` state to an empty array, effectively resetting the filter state. This allows the component to render the original list of invoices/expenses when the user returns back to the page.

## Related Issue
Closes #10 

## Acceptance Criteria
- [x] filtered invoices/expenses list returns back to original state after navigating to another page

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |
