### PR TITLE
fix: unable to view details of newly created invoice/expense: Error 404 Page Not Found

### DIFF
--- a/pages/expenses/[expenseId].js
+++ b/pages/expenses/[expenseId].js
@@ -16,7 +16,7 @@ export async function getStaticPaths() {
   client.close();
 
   return {
-    fallback: false,
+    fallback: 'blocking',
     paths: expenses.map(expense => ({
       params: { expenseId: expense._id.toString() },
     })),

--- a/pages/expenses/index.js
+++ b/pages/expenses/index.js
@@ -94,6 +94,6 @@ export async function getStaticProps() {
         status: expense.status,
       })),
     },
-    revalidate: 30,
+    revalidate: 5,
   };
 }

--- a/pages/invoices/[paymentId].js
+++ b/pages/invoices/[paymentId].js
@@ -46,7 +46,7 @@ export async function getStaticPaths() {
   client.close();
 
   return {
-    fallback: false,
+    fallback: 'blocking',
     paths: invoices.map(invoice => ({
       params: { paymentId: invoice._id.toString() },
     })),

--- a/pages/invoices/index.js
+++ b/pages/invoices/index.js
@@ -100,6 +100,6 @@ export async function getStaticProps() {
         items: invoice.items,
       })),
     },
-    revalidate: 30,
+    revalidate: 5,
   };
 }


### PR DESCRIPTION
## Description
This PR addresses an issue where, after creating a new invoice/expense and attempting to view its details, the user was redirected to a 404 error page. This problem arose because the `fallback` property was set to `false`, which prevented NextJS from generating new pages on the fly. To resolve this issue, the fallback property has been updated to `'blocking'`, indicating to NextJS that the array of paths is not exhaustive and that there may be additional pages to generate. This change will ensure that NextJS does not immediately return a 404 error page if the requested page cannot be found. Instead, it will pre-generate the page and display it to the user once it's ready. This fix will improve the user experience by ensuring that newly created invoices and expenses can be viewed without any errors.

## Type of Changes
|     | Type                       |
| --- | -------------------------- |
|  ✓   | :bug: Bug fix              |
|    | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |