### PR TITLE
fix: updating the invoice doesn't trigger a regeneration of the page automatically (#19)

### DIFF
--- a/pages/expenses/[expenseId].js
+++ b/pages/expenses/[expenseId].js
@@ -5,25 +5,7 @@ export default function ExpenseDetails(props) {
   return <PaymentDetail type="expenses" expenseData={props.expenseData} />;
 }
 
-export async function getStaticPaths() {
-  const client = await MongoClient.connect(process.env.NEXT_PUBLIC_API_TOKEN);
-
-  const db = client.db();
-  const expensesCollections = db.collection('expenses');
-
-  const expenses = await expensesCollections.find({}, { _id: 1 }).toArray();
-
-  client.close();
-
-  return {
-    fallback: 'blocking',
-    paths: expenses.map(expense => ({
-      params: { expenseId: expense._id.toString() },
-    })),
-  };
-}
-
-export async function getStaticProps(context) {
+export async function getServerSideProps(context) {
   const expenseId = context.params.expenseId;
 
   const client = await MongoClient.connect(process.env.NEXT_PUBLIC_API_TOKEN);
@@ -52,6 +34,56 @@ export async function getStaticProps(context) {
         status: selectedExpense.status,
       },
     },
-    revalidate: 10,
   };
 }
+
+// export async function getStaticPaths() {
+//   const client = await MongoClient.connect(process.env.NEXT_PUBLIC_API_TOKEN);
+
+//   const db = client.db();
+//   const expensesCollections = db.collection('expenses');
+
+//   const expenses = await expensesCollections.find({}, { _id: 1 }).toArray();
+
+//   client.close();
+
+//   return {
+//     fallback: 'blocking',
+//     paths: expenses.map(expense => ({
+//       params: { expenseId: expense._id.toString() },
+//     })),
+//   };
+// }
+
+// export async function getStaticProps(context) {
+//   const expenseId = context.params.expenseId;
+
+//   const client = await MongoClient.connect(process.env.NEXT_PUBLIC_API_TOKEN);
+
+//   const db = client.db();
+//   const expensesCollections = db.collection('expenses');
+
+//   const selectedExpense = await expensesCollections.findOne({
+//     _id: new ObjectId(expenseId),
+//   });
+
+//   client.close();
+
+//   return {
+//     props: {
+//       expenseData: {
+//         id: selectedExpense._id.toString(),
+//         merchant: selectedExpense.merchant,
+//         referenceNo: selectedExpense.referenceNo,
+//         accountNo: selectedExpense.accountNo,
+//         accountType: selectedExpense.accountType,
+//         expenseAmount: selectedExpense.expenseAmount,
+//         expenseDueDate: selectedExpense.expenseDueDate,
+//         expenseCategory: selectedExpense.expenseCategory,
+//         notes: selectedExpense.notes,
+//         status: selectedExpense.status,
+//       },
+//     },
+//     revalidate: 10,
+//   };
+// }

--- a/pages/expenses/index.js
+++ b/pages/expenses/index.js
@@ -69,7 +69,7 @@ export default function Expenses(props) {
   );
 }
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   const client = await MongoClient.connect(process.env.NEXT_PUBLIC_API_TOKEN);
 
   const db = client.db();
@@ -94,6 +94,34 @@ export async function getStaticProps() {
         status: expense.status,
       })),
     },
-    revalidate: 5,
   };
 }
+
+// export async function getStaticProps() {
+//   const client = await MongoClient.connect(process.env.NEXT_PUBLIC_API_TOKEN);
+
+//   const db = client.db();
+//   const expensesCollections = db.collection('expenses');
+
+//   const expenses = await expensesCollections.find().toArray();
+
+//   client.close();
+
+//   return {
+//     props: {
+//       expenses: expenses.map(expense => ({
+//         id: expense._id.toString(),
+//         merchant: expense.merchant,
+//         referenceNo: expense.referenceNo,
+//         accountNo: expense.accountNo,
+//         accountType: expense.accountType,
+//         expenseAmount: expense.expenseAmount,
+//         expenseDueDate: expense.expenseDueDate,
+//         expenseCategory: expense.expenseCategory,
+//         notes: expense.notes,
+//         status: expense.status,
+//       })),
+//     },
+//     revalidate: 5,
+//   };
+// }

--- a/pages/invoices/[paymentId].js
+++ b/pages/invoices/[paymentId].js
@@ -35,25 +35,7 @@ export default function PaymentDetails(props) {
   );
 }
 
-export async function getStaticPaths() {
-  const client = await MongoClient.connect(process.env.NEXT_PUBLIC_API_TOKEN);
-
-  const db = client.db();
-  const invoicesCollections = db.collection('invoices');
-
-  const invoices = await invoicesCollections.find({}, { _id: 1 }).toArray();
-
-  client.close();
-
-  return {
-    fallback: 'blocking',
-    paths: invoices.map(invoice => ({
-      params: { paymentId: invoice._id.toString() },
-    })),
-  };
-}
-
-export async function getStaticProps(context) {
+export async function getServerSideProps(context) {
   const paymentId = context.params.paymentId;
 
   const client = await MongoClient.connect(process.env.NEXT_PUBLIC_API_TOKEN);
@@ -88,6 +70,62 @@ export async function getStaticProps(context) {
         items: selectedPayment.items,
       },
     },
-    revalidate: 10,
   };
 }
+
+// export async function getStaticPaths() {
+//   const client = await MongoClient.connect(process.env.NEXT_PUBLIC_API_TOKEN);
+
+//   const db = client.db();
+//   const invoicesCollections = db.collection('invoices');
+
+//   const invoices = await invoicesCollections.find({}, { _id: 1 }).toArray();
+
+//   client.close();
+
+//   return {
+//     fallback: 'blocking',
+//     paths: invoices.map(invoice => ({
+//       params: { paymentId: invoice._id.toString() },
+//     })),
+//   };
+// }
+
+// export async function getStaticProps(context) {
+//   const paymentId = context.params.paymentId;
+
+//   const client = await MongoClient.connect(process.env.NEXT_PUBLIC_API_TOKEN);
+
+//   const db = client.db();
+//   const invoicesCollections = db.collection('invoices');
+
+//   const selectedPayment = await invoicesCollections.findOne({
+//     _id: new ObjectId(paymentId),
+//   });
+
+//   client.close();
+
+//   return {
+//     props: {
+//       paymentData: {
+//         id: selectedPayment._id.toString(),
+//         street: selectedPayment.street,
+//         city: selectedPayment.city,
+//         postal: selectedPayment.postal,
+//         country: selectedPayment.country,
+//         clientName: selectedPayment.clientName,
+//         clientEmail: selectedPayment.clientEmail,
+//         clientStreet: selectedPayment.clientStreet,
+//         clientCity: selectedPayment.clientCity,
+//         clientPostal: selectedPayment.clientPostal,
+//         clientCountry: selectedPayment.clientCountry,
+//         invoiceDate: selectedPayment.invoiceDate,
+//         paymentTerms: selectedPayment.paymentTerms,
+//         description: selectedPayment.description,
+//         status: selectedPayment.status,
+//         items: selectedPayment.items,
+//       },
+//     },
+//     revalidate: 10,
+//   };
+// }

--- a/pages/invoices/index.js
+++ b/pages/invoices/index.js
@@ -69,7 +69,7 @@ export default function Invoices(props) {
   );
 }
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   const client = await MongoClient.connect(process.env.NEXT_PUBLIC_API_TOKEN);
 
   const db = client.db();
@@ -100,6 +100,40 @@ export async function getStaticProps() {
         items: invoice.items,
       })),
     },
-    revalidate: 5,
   };
 }
+
+// export async function getStaticProps() {
+//   const client = await MongoClient.connect(process.env.NEXT_PUBLIC_API_TOKEN);
+
+//   const db = client.db();
+//   const invoicesCollections = db.collection('invoices');
+
+//   const invoices = await invoicesCollections.find().toArray();
+
+//   client.close();
+
+//   return {
+//     props: {
+//       invoices: invoices.map(invoice => ({
+//         id: invoice._id.toString(),
+//         street: invoice.street,
+//         city: invoice.city,
+//         postal: invoice.postal,
+//         country: invoice.country,
+//         clientName: invoice.clientName,
+//         clientEmail: invoice.clientEmail,
+//         clientStreet: invoice.clientStreet,
+//         clientCity: invoice.clientCity,
+//         clientPostal: invoice.clientPostal,
+//         clientCountry: invoice.clientCountry,
+//         invoiceDate: invoice.invoiceDate,
+//         paymentTerms: invoice.paymentTerms,
+//         description: invoice.description,
+//         status: invoice.status,
+//         items: invoice.items,
+//       })),
+//     },
+//     revalidate: 5,
+//   };
+// }


### PR DESCRIPTION
## Description
This PR resolves the issue of the page not reflecting the updated data automatically when users updated an invoice or expense. Although the `revalidate` prop was set to 10 seconds in the `getStaticProps` function, the page still required manual refresh to display the changes.

To address this issue, I made the following changes:
- [x] replaced the usage of `getStaticProps` with `getServerSideProps`
- [x]  removed the `revalidate` prop as it is not required anymore. With `getServerSideProps`, the page will be dynamically regenerated on each request, eliminating the need for explicit revalidation
   
By switching to `getServerSideProps`, the page is regenerated on each request, ensuring that the latest data is always fetched from the server immediately after updating an invoice/expense, eliminating the need for manual page refreshes. This ensures that users will see the most up-to-date data without any manual intervention

## Type of Changes
|     | Type                       |
| --- | -------------------------- |
|   ✓ | :bug: Bug fix              |
|   | :sparkles: New feature     |
|   ✓  | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |