### PR TITLE
fix: reduce callback function not correctly summing expenses in props.expensesStats array

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -24,7 +24,8 @@ export default function Home(props) {
   });
 
   const expensesTotal = props.expensesStats.reduce(
-    (a, b) => Number(a.amount) + Number(b.amount)
+    (acc, curr) => acc + Number(curr.amount),
+    0
   );
 
   return (


### PR DESCRIPTION
## Description
Previously, the reduce callback function in the code returned the sum of the current and next values. This approach worked correctly for two expenses, but when a third expense was added, the code broke and returned NaN. To address this issue, I improved the callback function to correctly accumulate the total by adding the current value `Number(curr.amount)` to the accumulator `acc`. With these modifications, the code now properly calculates and stores the total sum of all the amounts in the `props.expensesStats` array in the `expensesTotal` variable.

## Related Issue
Closes #21 

## Type of Changes
|     | Type                       |
| --- | -------------------------- |
|   ✓ | :bug: Bug fix              |
|    | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |