### PR TITLE
fix: display correct invoice date by accounting for timezone offset

### DIFF
--- a/components/PaymentDetail.js
+++ b/components/PaymentDetail.js
@@ -56,8 +56,16 @@ export default function PaymentDetail({
     year: 'numeric',
   };
 
+  const adjustedDate =
+    type === 'invoices'
+      ? new Date(date.getTime() + date.getTimezoneOffset() * 60000)
+      : '';
+
   const invoiceDate =
-    type === 'invoices' ? date.toLocaleDateString('en-US', options) : '';
+    type === 'invoices'
+      ? adjustedDate.toLocaleDateString('en-US', options)
+      : '';
+
   const formattedDate =
     type === 'invoices'
       ? paymentDueDate.toLocaleDateString('en-US', options)


### PR DESCRIPTION
## Description
This PR resolves the issue of the date displaying one day earlier than the stored date in the database. I calculated the timezone offset `getTimezoneOffset()` method, which returns the difference between the local time and UTC time in minutes, and multiplied it by 60000. I then applied it to the date before formatting it using the provided options and the `toLocaleDateString()` method, that way I can ensure that the displayed date aligned with the date stored in the database.


## Related Issue
Closes #23 

## Type of Changes
|     | Type                       |
| --- | -------------------------- |
|  ✓   | :bug: Bug fix              |
|    | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |
