### PR TITLE
feat: added expense bar graph to chart and legend to differentiate invoices and expenses in homepage

### DIFF
--- a/components/chart/Chart.js
+++ b/components/chart/Chart.js
@@ -28,7 +28,13 @@ export default function Chart(props) {
             icon={faSquare}
             className="text-brightPurple"
           ></FontAwesomeIcon>
-          <p className="text-[#bac0e1] text-xs">Invoices</p>
+          <p
+            className={`${
+              props.isDarkMode ? 'text-[#bac0e1]' : 'text-[#8c90a7]'
+            } text-xs`}
+          >
+            Invoices
+          </p>
         </div>
 
         <div className="flex items-center gap-2">
@@ -36,7 +42,13 @@ export default function Chart(props) {
             icon={faSquare}
             className="text-[#3b278b]"
           ></FontAwesomeIcon>
-          <p className="text-[#bac0e1] text-xs">Expenses</p>
+          <p
+            className={`${
+              props.isDarkMode ? 'text-[#bac0e1]' : 'text-[#8c90a7]'
+            } text-xs`}
+          >
+            Expenses
+          </p>
         </div>
       </div>
 

--- a/components/chart/Chart.js
+++ b/components/chart/Chart.js
@@ -1,7 +1,9 @@
 import ChartBar from './ChartBar';
 
 export default function Chart(props) {
-  const dataPointValues = props.dataPoints.map(dataPoint => dataPoint.value);
+  const dataPointValues = props.dataPoints.map(
+    dataPoint => dataPoint.invoiceValue
+  );
   const totalMax = Math.max(...dataPointValues);
 
   return (
@@ -15,7 +17,7 @@ export default function Chart(props) {
       {props.dataPoints.map(dataPoint => (
         <ChartBar
           key={dataPoint.label}
-          value={dataPoint.value}
+          value={dataPoint.invoiceValue}
           maxValue={totalMax}
           label={dataPoint.label}
           isDarkMode={props.isDarkMode}

--- a/components/chart/Chart.js
+++ b/components/chart/Chart.js
@@ -6,6 +6,11 @@ export default function Chart(props) {
   );
   const totalMax = Math.max(...dataPointValues);
 
+  const expenseDataPointValues = props.dataPoints.map(
+    expenseDataPoint => expenseDataPoint.expenseValue
+  );
+  const expenseTotalMax = Math.max(...expenseDataPointValues);
+
   return (
     <div
       className={`${
@@ -18,7 +23,9 @@ export default function Chart(props) {
         <ChartBar
           key={dataPoint.label}
           value={dataPoint.invoiceValue}
+          expenseValue={dataPoint.expenseValue}
           maxValue={totalMax}
+          expenseMaxValue={expenseTotalMax}
           label={dataPoint.label}
           isDarkMode={props.isDarkMode}
         />

--- a/components/chart/Chart.js
+++ b/components/chart/Chart.js
@@ -4,10 +4,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSquare } from '@fortawesome/free-solid-svg-icons';
 
 export default function Chart(props) {
-  const dataPointValues = props.dataPoints.map(
+  const invoiceDataPointValues = props.dataPoints.map(
     dataPoint => dataPoint.invoiceValue
   );
-  const totalMax = Math.max(...dataPointValues);
+  const invoiceTotalMax = Math.max(...invoiceDataPointValues);
 
   const expenseDataPointValues = props.dataPoints.map(
     expenseDataPoint => expenseDataPoint.expenseValue
@@ -56,9 +56,9 @@ export default function Chart(props) {
         {props.dataPoints.map(dataPoint => (
           <ChartBar
             key={dataPoint.label}
-            value={dataPoint.invoiceValue}
+            invoiceValue={dataPoint.invoiceValue}
             expenseValue={dataPoint.expenseValue}
-            maxValue={totalMax}
+            invoiceMaxValue={invoiceTotalMax}
             expenseMaxValue={expenseTotalMax}
             label={dataPoint.label}
             isDarkMode={props.isDarkMode}

--- a/components/chart/Chart.js
+++ b/components/chart/Chart.js
@@ -1,5 +1,8 @@
 import ChartBar from './ChartBar';
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSquare } from '@fortawesome/free-solid-svg-icons';
+
 export default function Chart(props) {
   const dataPointValues = props.dataPoints.map(
     dataPoint => dataPoint.invoiceValue
@@ -17,19 +20,39 @@ export default function Chart(props) {
         props.isDarkMode
           ? 'text-draft bg-mainPurple'
           : 'text-grayerPurple bg-[#fdfdfd]'
-      } text-center w-full h-72 flex justify-around rounded-lg px-4 py-6`}
+      } text-center w-full h-72 flex flex-col gap-4 rounded-lg px-4 py-6`}
     >
-      {props.dataPoints.map(dataPoint => (
-        <ChartBar
-          key={dataPoint.label}
-          value={dataPoint.invoiceValue}
-          expenseValue={dataPoint.expenseValue}
-          maxValue={totalMax}
-          expenseMaxValue={expenseTotalMax}
-          label={dataPoint.label}
-          isDarkMode={props.isDarkMode}
-        />
-      ))}
+      <div className="flex justify-end gap-4 px-2">
+        <div className="flex items-center gap-2">
+          <FontAwesomeIcon
+            icon={faSquare}
+            className="text-brightPurple"
+          ></FontAwesomeIcon>
+          <p className="text-[#bac0e1] text-xs">Invoices</p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <FontAwesomeIcon
+            icon={faSquare}
+            className="text-[#3b278b]"
+          ></FontAwesomeIcon>
+          <p className="text-[#bac0e1] text-xs">Expenses</p>
+        </div>
+      </div>
+
+      <div className="h-full flex justify-around">
+        {props.dataPoints.map(dataPoint => (
+          <ChartBar
+            key={dataPoint.label}
+            value={dataPoint.invoiceValue}
+            expenseValue={dataPoint.expenseValue}
+            maxValue={totalMax}
+            expenseMaxValue={expenseTotalMax}
+            label={dataPoint.label}
+            isDarkMode={props.isDarkMode}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/components/chart/ChartBar.js
+++ b/components/chart/ChartBar.js
@@ -14,7 +14,7 @@ export default function ChartBar(props) {
 
   return (
     <div className="h-full flex flex-col items-center gap-2">
-      <div className="h-full flex gap-2">
+      <div className="h-full flex gap-1 md:gap-2">
         <div
           className={`${
             props.isDarkMode

--- a/components/chart/ChartBar.js
+++ b/components/chart/ChartBar.js
@@ -1,26 +1,51 @@
 export default function ChartBar(props) {
-  let barFillHeight = '0%';
+  let invoiceBarFillHeight = '0%';
+  let expenseBarFillHeight = '0%';
 
   if (props.maxValue > 0) {
-    barFillHeight = Math.round((props.value / props.maxValue) * 100) + '%';
+    invoiceBarFillHeight =
+      Math.round((props.value / props.maxValue) * 100) + '%';
+  }
+
+  if (props.expenseMaxValue > 0) {
+    expenseBarFillHeight =
+      Math.round((props.expenseValue / props.expenseMaxValue) * 100) + '%';
   }
 
   return (
     <div className="h-full flex flex-col items-center gap-2">
-      <div
-        className={`${
-          props.isDarkMode
-            ? 'bg-borderPurple border-borderPurple'
-            : 'bg-[#ededf1] border-[#ededf1]'
-        } h-full w-4 flex flex-col justify-end border-[1px] rounded-md overflow-hidden`}
-      >
+      <div className="h-full flex gap-2">
         <div
-          className="chart-bar bg-brightPurple w-full inline-block"
-          style={{ height: barFillHeight }}
+          className={`${
+            props.isDarkMode
+              ? 'bg-borderPurple border-borderPurple'
+              : 'bg-[#ededf1] border-[#ededf1]'
+          } h-full w-4 flex flex-col justify-end border-[1px] rounded-md overflow-hidden`}
         >
-          <span className="tooltiptext text-white bg-darkPurple text-sm text-center max-w-full absolute rounded-md p-2 ml-1 z-50">
-            {`$${props.value.toFixed(2)}`}
-          </span>
+          <div
+            className="chart-bar bg-brightPurple w-full inline-block"
+            style={{ height: invoiceBarFillHeight }}
+          >
+            <span className="tooltiptext text-white bg-darkPurple text-sm text-center max-w-full absolute rounded-md p-2 ml-1 z-50">
+              {`$${props.value.toFixed(2)}`}
+            </span>
+          </div>
+        </div>
+        <div
+          className={`${
+            props.isDarkMode
+              ? 'bg-borderPurple border-borderPurple'
+              : 'bg-[#ededf1] border-[#ededf1]'
+          } h-full w-4 flex flex-col justify-end border-[1px] rounded-md overflow-hidden`}
+        >
+          <div
+            className="chart-bar bg-[#3b278b] w-full inline-block"
+            style={{ height: expenseBarFillHeight }}
+          >
+            <span className="tooltiptext text-white bg-darkPurple text-sm text-center max-w-full absolute rounded-md p-2 ml-1 z-50">
+              {`$${props.expenseValue.toFixed(2)}`}
+            </span>
+          </div>
         </div>
       </div>
       <div className="font-bold text-sm text-center">{props.label}</div>

--- a/components/chart/ChartBar.js
+++ b/components/chart/ChartBar.js
@@ -2,9 +2,9 @@ export default function ChartBar(props) {
   let invoiceBarFillHeight = '0%';
   let expenseBarFillHeight = '0%';
 
-  if (props.maxValue > 0) {
+  if (props.invoiceMaxValue > 0) {
     invoiceBarFillHeight =
-      Math.round((props.value / props.maxValue) * 100) + '%';
+      Math.round((props.invoiceValue / props.invoiceMaxValue) * 100) + '%';
   }
 
   if (props.expenseMaxValue > 0) {
@@ -27,7 +27,7 @@ export default function ChartBar(props) {
             style={{ height: invoiceBarFillHeight }}
           >
             <span className="tooltiptext text-white bg-darkPurple text-sm text-center max-w-full absolute rounded-md p-2 ml-1 z-50">
-              {`$${props.value.toFixed(2)}`}
+              {`$${props.invoiceValue.toFixed(2)}`}
             </span>
           </div>
         </div>

--- a/components/chart/ChartBar.js
+++ b/components/chart/ChartBar.js
@@ -20,7 +20,7 @@ export default function ChartBar(props) {
             props.isDarkMode
               ? 'bg-borderPurple border-borderPurple'
               : 'bg-[#ededf1] border-[#ededf1]'
-          } h-full w-4 flex flex-col justify-end border-[1px] rounded-md overflow-hidden`}
+          } h-full w-3 flex flex-col justify-end border-[1px] rounded-md overflow-hidden md:w-4`}
         >
           <div
             className="chart-bar bg-brightPurple w-full inline-block"
@@ -36,7 +36,7 @@ export default function ChartBar(props) {
             props.isDarkMode
               ? 'bg-borderPurple border-borderPurple'
               : 'bg-[#ededf1] border-[#ededf1]'
-          } h-full w-4 flex flex-col justify-end border-[1px] rounded-md overflow-hidden`}
+          } h-full w-3 flex flex-col justify-end border-[1px] rounded-md overflow-hidden md:w-4`}
         >
           <div
             className="chart-bar bg-[#3b278b] w-full inline-block"

--- a/components/chart/InvoicesChart.js
+++ b/components/chart/InvoicesChart.js
@@ -5,50 +5,62 @@ export default function InvoicesChart(props) {
     {
       label: 'Jan',
       invoiceValue: 0,
+      expenseValue: 0,
     },
     {
       label: 'Feb',
       invoiceValue: 0,
+      expenseValue: 0,
     },
     {
       label: 'Mar',
       invoiceValue: 0,
+      expenseValue: 0,
     },
     {
       label: 'Apr',
       invoiceValue: 0,
+      expenseValue: 0,
     },
     {
       label: 'May',
       invoiceValue: 0,
+      expenseValue: 0,
     },
     {
       label: 'Jun',
       invoiceValue: 0,
+      expenseValue: 0,
     },
     {
       label: 'Jul',
       invoiceValue: 0,
+      expenseValue: 0,
     },
     {
       label: 'Aug',
       invoiceValue: 0,
+      expenseValue: 0,
     },
     {
       label: 'Sep',
       invoiceValue: 0,
+      expenseValue: 0,
     },
     {
       label: 'Oct',
       invoiceValue: 0,
+      expenseValue: 0,
     },
     {
       label: 'Nov',
       invoiceValue: 0,
+      expenseValue: 0,
     },
     {
       label: 'Dec',
       invoiceValue: 0,
+      expenseValue: 0,
     },
   ];
 
@@ -61,6 +73,15 @@ export default function InvoicesChart(props) {
     const total = invoice.total.reduce((acc, val) => acc + val, 0);
 
     chartDataPoints[invoiceMonth].invoiceValue += total;
+  }
+
+  for (const expense of props.expenses) {
+    const dateObj = new Date(expense.date);
+    dateObj.setHours(dateObj.getHours() + dateObj.getTimezoneOffset() / 60);
+
+    const expenseMonth = dateObj.getMonth();
+
+    chartDataPoints[expenseMonth].expenseValue += Number(expense.amount);
   }
 
   return <Chart dataPoints={chartDataPoints} isDarkMode={props.isDarkMode} />;

--- a/components/chart/InvoicesChart.js
+++ b/components/chart/InvoicesChart.js
@@ -4,51 +4,51 @@ export default function InvoicesChart(props) {
   const chartDataPoints = [
     {
       label: 'Jan',
-      value: 0,
+      invoiceValue: 0,
     },
     {
       label: 'Feb',
-      value: 0,
+      invoiceValue: 0,
     },
     {
       label: 'Mar',
-      value: 0,
+      invoiceValue: 0,
     },
     {
       label: 'Apr',
-      value: 0,
+      invoiceValue: 0,
     },
     {
       label: 'May',
-      value: 0,
+      invoiceValue: 0,
     },
     {
       label: 'Jun',
-      value: 0,
+      invoiceValue: 0,
     },
     {
       label: 'Jul',
-      value: 0,
+      invoiceValue: 0,
     },
     {
       label: 'Aug',
-      value: 0,
+      invoiceValue: 0,
     },
     {
       label: 'Sep',
-      value: 0,
+      invoiceValue: 0,
     },
     {
       label: 'Oct',
-      value: 0,
+      invoiceValue: 0,
     },
     {
       label: 'Nov',
-      value: 0,
+      invoiceValue: 0,
     },
     {
       label: 'Dec',
-      value: 0,
+      invoiceValue: 0,
     },
   ];
 
@@ -60,7 +60,7 @@ export default function InvoicesChart(props) {
 
     const total = invoice.total.reduce((acc, val) => acc + val, 0);
 
-    chartDataPoints[invoiceMonth].value += total;
+    chartDataPoints[invoiceMonth].invoiceValue += total;
   }
 
   return <Chart dataPoints={chartDataPoints} isDarkMode={props.isDarkMode} />;

--- a/components/chart/PaymentsChart.js
+++ b/components/chart/PaymentsChart.js
@@ -1,6 +1,6 @@
 import Chart from './Chart';
 
-export default function InvoicesChart(props) {
+export default function PaymentsChart(props) {
   const chartDataPoints = [
     {
       label: 'Jan',

--- a/pages/index.js
+++ b/pages/index.js
@@ -62,6 +62,7 @@ export default function Home(props) {
 
           <InvoicesChart
             invoices={props.invoicesStats}
+            expenses={props.expensesStats}
             isDarkMode={isDarkMode}
           />
         </section>

--- a/pages/index.js
+++ b/pages/index.js
@@ -12,6 +12,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 
 export default function Home(props) {
+  console.log(props);
   const { isDarkMode } = useContext(Context);
 
   let invoicesTotal = 0;
@@ -93,6 +94,7 @@ export async function getStaticProps() {
       expensesStats: expenses.map(expense => ({
         amount: expense.expenseAmount,
         category: expense.expenseCategory,
+        date: expense.expenseDueDate,
       })),
     },
     revalidate: 5,

--- a/pages/index.js
+++ b/pages/index.js
@@ -12,7 +12,6 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 
 export default function Home(props) {
-  console.log(props);
   const { isDarkMode } = useContext(Context);
 
   let invoicesTotal = 0;

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,7 +3,7 @@ import Head from 'next/head';
 import { useContext } from 'react';
 import { Context } from '@/components/context/StateContext';
 import DataStats from '@/components/DataStats';
-import InvoicesChart from '@/components/chart/InvoicesChart';
+import PaymentsChart from '@/components/chart/PaymentsChart';
 
 import {
   faEnvelope,
@@ -60,7 +60,7 @@ export default function Home(props) {
             />
           </section>
 
-          <InvoicesChart
+          <PaymentsChart
             invoices={props.invoicesStats}
             expenses={props.expensesStats}
             isDarkMode={isDarkMode}

--- a/pages/index.js
+++ b/pages/index.js
@@ -91,6 +91,7 @@ export async function getStaticProps() {
       })),
       expensesStats: expenses.map(expense => ({
         amount: expense.expenseAmount,
+        category: expense.expenseCategory,
       })),
     },
     revalidate: 5,


### PR DESCRIPTION
## Description
The previous version of the homepage only displayed a bar graph representing the total invoice amount for each month. This pull request enhances the homepage by adding a second bar graph to represent expenses. The expenses bar graph is visually distinguished from the invoice bar graph by using a different fill color. Additionally, a legend has been introduced at the top right corner of the chart to assist users in identifying the invoice and expense bars based on their respective colors. 

## Type of Changes
|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |
